### PR TITLE
Add license_file entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     .readlines()[-1]
     .split()[-1]
     .strip("\"'"),
-    license="GPLv3",
+    license="MIT",
+    license_file="LICENSE",
     description="Analyze, visualize and process sound field data recorded by "
     "spherical microphone arrays.",
     long_description=open("README.rst", mode="r", encoding="utf-8").read(),


### PR DESCRIPTION
This will bundle `LICENSE` file when building sdist and wheels, which in turn is required by conda-forge (see https://github.com/conda-forge/sound_field_analysis-feedstock/pull/9)